### PR TITLE
Update link to TL homepage.

### DIFF
--- a/sample-book.tex
+++ b/sample-book.tex
@@ -1052,8 +1052,8 @@ The following headings are not supported: \doccmd{subsubsection} and \doccmd{sub
 
 \section{\TL Website}\label{sec:website}
 The website for the \TL packages is located at
-\url{https://github.com/Tufte-LaTeX/tufte-latex}.  On our website, you'll find
-links to our \smallcaps{svn} repository, mailing lists, bug tracker, and documentation.
+\url{https://tufte-latex.github.io/tufte-latex}.  On our website, you'll find
+links to our \smallcaps{git} repository, mailing lists, bug tracker, and documentation.
 
 \section{\TL Mailing Lists}\label{sec:mailing-lists}
 There are two mailing lists for the \TL project:

--- a/sample-handout.tex
+++ b/sample-handout.tex
@@ -280,8 +280,8 @@ mentioned in this handout), please see the sample book.
 \section{Support}\label{sec:support}
 
 The website for the Tufte-\LaTeX\ packages is located at
-\url{https://github.com/Tufte-LaTeX/tufte-latex}.  On our website, you'll find
-links to our \smallcaps{svn} repository, mailing lists, bug tracker, and documentation.
+\url{https://tufte-latex.github.io/tufte-latex}.  On our website, you'll find
+links to our \smallcaps{git} repository, mailing lists, bug tracker, and documentation.
 
 \bibliography{sample-handout}
 \bibliographystyle{plainnat}


### PR DESCRIPTION
SVN has been replaced by GIT.